### PR TITLE
Add inputs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,12 @@
+name: Test action
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: shenxianpeng/cpp-linter-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: 2bndy5/cpp-linter-action@add-inputs
+      # - uses: actions/checkout@v2
+      - uses: shenxianpeng/cpp-linter-action@master
         with:
           style: file
           extensions: 'cpp'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: shenxianpeng/cpp-linter-action@master
+      - uses: 2bndy5/cpp-linter-action@add-input
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,5 +8,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: 2bndy5/cpp-linter-action@add-inputs
+        with:
+          style: file
+          extensions: 'cpp'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: 2bndy5/cpp-linter-action@add-input
+      - uses: 2bndy5/cpp-linter-action@add-inputs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test action
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="shenxianpeng <20297606+shenxianpeng@users.noreply.github.com>"
 
 # WORKDIR /build
 RUN apt-get update
-RUN apt-get -qq -y install curl clang-tidy cmake jq clang clang-format
+RUN apt-get -y install curl clang-tidy cmake jq clang clang-format
 
 COPY runchecks.sh /entrypoint.sh
 RUN chmod +x /entrypoint.ch

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ LABEL com.github.actions.color="gray-dark"
 LABEL repository="https://github.com/shenxianpeng/cpp-linter-action"
 LABEL maintainer="shenxianpeng <20297606+shenxianpeng@users.noreply.github.com>"
 
-WORKDIR /build
+# WORKDIR /build
 RUN apt-get update
 RUN apt-get -qq -y install curl clang-tidy cmake jq clang clang-format
 
-ADD runchecks.sh /entrypoint.sh
-COPY . .
-CMD ["bash", "/entrypoint.sh"]
+COPY runchecks.sh /entrypoint.sh
+RUN chmod +x /entrypoint.ch
+CMD ["bash", "/entrypoint.sh", "$@"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN apt-get -y install curl clang-tidy cmake jq clang clang-format
 
 COPY runchecks.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-CMD ["bash", "/entrypoint.sh"]
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ RUN apt-get update
 RUN apt-get -y install curl clang-tidy cmake jq clang clang-format
 
 COPY runchecks.sh /entrypoint.sh
-RUN chmod +x /entrypoint.ch
-CMD ["bash", "/entrypoint.sh", "$@"]
+RUN chmod +x /entrypoint.sh
+CMD ["bash", "/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Github Actions for linting the C/C++ code. Integrated clang-tidy, clang-format c
 
 Just create a `yml` file under your GitHub repository. For example `.github/workflows/cpp-linter.yml`
 
+!!! Requires `secrets.GITHUB_TOKEN` set to an environment variable name "GITHUB_TOKEN".
+
 ```yml
 name: cpp-linter
 
@@ -16,10 +18,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: C/C++ Lint Action
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: shenxianpeng/cpp-linter-action@master
-    env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          style: 'file'
 ```
+## Optional Inputs
+
+| Input name | default value | Description |
+|------------|---------------|-------------|
+| style | 'llvm' | The style rules to use. Set this to 'file' to have clang-format use the closest relative .clang-format file. |
+| extensions | 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx' | The file extensions to run the action against. This is a comma-separated string. |
 
 ## Results of GitHub Actions
 

--- a/action.yml
+++ b/action.yml
@@ -9,8 +9,13 @@ inputs:
     description: "The style rules to use (defaults to 'llvm'). Set this to file to make 'file' to have clang-format use the closest relative .clang-format file."
     required: false
     default: 'llvm'
+  extensions:
+    desciption: "The file extensions to run the action against. This defaults to 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'".
+    required: false
+    default: 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.style }}
+    - ${{ inputs.extensions }}

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   color: 'green'
 inputs:
   style: # the specific style rules
-    description: "The style rules to use (defaults to 'llvm'). Set this to file to make 'file' to have clang-format use the closest relative .clang-format file."
+    description: "The style rules to use (defaults to 'llvm'). Set this to 'file' to have clang-format use the closest relative .clang-format file."
     required: false
     default: 'llvm'
   extensions:

--- a/action.yml
+++ b/action.yml
@@ -10,9 +10,9 @@ inputs:
     required: false
     default: 'llvm'
   extensions:
-    desciption: "The file extensions to run the action against. This defaults to 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'".
+    description: "The file extensions to run the action against. This comma-separated string defaults to 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'".
     required: false
-    default: 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'
+    default: "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx"
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: 'llvm'
   extensions:
-    description: "The file extensions to run the action against. This comma-separated string defaults to 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'".
+    description: "The file extensions to run the action against. This comma-separated string defaults to 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'."
     required: false
     default: "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx"
 runs:

--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,9 @@ branding:
   color: 'green'
 inputs:
   style: # the specific style rules
-  description: "The style rules to use (defaults to 'LLVM'). Set this to file to make 'file' to have clang-format use the closest relative '.clang-format' file."
-  required: false
-  default: 'llvm'
+    description: "The style rules to use (defaults to 'llvm'). Set this to file to make 'file' to have clang-format use the closest relative .clang-format file."
+    required: false
+    default: 'llvm'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,13 @@ author: shenxianpeng
 branding:
   icon: 'check-circle'
   color: 'green'
+inputs:
+  style: # the specific style rules
+  description: "The style rules to use (defaults to 'LLVM'). Set this to file to make 'file' to have clang-format use the closest relative '.clang-format' file."
+  required: false
+  default: 'llvm'
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  args:
+    - ${{ inputs.style }}

--- a/demo/.clang-format
+++ b/demo/.clang-format
@@ -1,0 +1,3 @@
+---
+Language:        Cpp
+BasedOnStyle:  WebKit

--- a/demo/compile_commands.json
+++ b/demo/compile_commands.json
@@ -1,0 +1,7 @@
+[
+{
+  "directory": ".",
+  "command": "/usr/bin/g++ -Wall -Werror demo.cpp",
+  "file": "/demo.cpp"
+}
+]

--- a/demo/demo.cpp
+++ b/demo/demo.cpp
@@ -1,0 +1,15 @@
+
+#include <stdio.h>
+
+
+
+
+int main(){
+
+    printf("Hello world!\n");
+
+    return 0;}
+
+
+
+/* This is an ugly test code */

--- a/runchecks.sh
+++ b/runchecks.sh
@@ -4,7 +4,8 @@ if [[ -z "$GITHUB_TOKEN" ]]; then
 	echo "The GITHUB_TOKEN is required."
 	exit 1
 fi
-
+args=("$@")
+FMT_STYLE=${args[0]}
 FILES_LINK=`jq -r '.pull_request._links.self.href' "$GITHUB_EVENT_PATH"`/files
 echo "Files = $FILES_LINK"
 
@@ -31,7 +32,7 @@ for i in "${URLS[@]}"
 do
    filename=`basename $i`
    clang-tidy $filename -checks=boost-*,bugprone-*,performance-*,readability-*,portability-*,modernize-*,clang-analyzer-cplusplus-*,clang-analyzer-*,cppcoreguidelines-* >> clang-tidy-report.txt
-   clang-format -style=$INPUT_STYLE--dry-run -Werror $filename || echo "File: $filename not formatted!" >> clang-format-report.txt
+   clang-format -style=$FMT_STYLE --dry-run -Werror $filename || echo "File: $filename not formatted!" >> clang-format-report.txt
 done
 
 PAYLOAD_TIDY=`cat clang-tidy-report.txt`

--- a/runchecks.sh
+++ b/runchecks.sh
@@ -20,7 +20,7 @@ cd files
 for i in "${URLS[@]}"
 do
    echo "Downloading $i"
-   curl -LOk --remote-name $i 
+   curl -LOk --remote-name $i
 done
 
 echo "Files downloaded!"
@@ -31,13 +31,13 @@ for i in "${URLS[@]}"
 do
    filename=`basename $i`
    clang-tidy $filename -checks=boost-*,bugprone-*,performance-*,readability-*,portability-*,modernize-*,clang-analyzer-cplusplus-*,clang-analyzer-*,cppcoreguidelines-* >> clang-tidy-report.txt
-   clang-format --dry-run -Werror $filename || echo "File: $filename not formatted!" >> clang-format-report.txt
+   clang-format -style=$INPUT_STYLE--dry-run -Werror $filename || echo "File: $filename not formatted!" >> clang-format-report.txt
 done
 
 PAYLOAD_TIDY=`cat clang-tidy-report.txt`
 PAYLOAD_FORMAT=`cat clang-format-report.txt`
 COMMENTS_URL=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.comments_url)
-  
+
 echo $COMMENTS_URL
 echo "Clang-tidy errors:"
 echo $PAYLOAD_TIDY

--- a/runchecks.sh
+++ b/runchecks.sh
@@ -7,7 +7,7 @@ fi
 
 args=("$@")
 FMT_STYLE=${args[0]}
-IFS=',' read -a FILE_EXT_LIST <<< ${args[1]}
+IFS=',' read -r -a FILE_EXT_LIST <<< "${args[1]}"
 
 FILES_LINK=`jq -r '.pull_request._links.self.href' "$GITHUB_EVENT_PATH"`/files
 echo "Files = $FILES_LINK"
@@ -51,7 +51,7 @@ for i in "${URLS[@]}"
 do
    filename=`basename $i`
    clang-tidy $filename -checks=boost-*,bugprone-*,performance-*,readability-*,portability-*,modernize-*,clang-analyzer-cplusplus-*,clang-analyzer-*,cppcoreguidelines-* >> clang-tidy-report.txt
-   clang-format -style=$FMT_STYLE --dry-run -Werror $filename || echo "File: $filename not formatted!" >> clang-format-report.txt
+   clang-format -style="$FMT_STYLE" --dry-run -Werror "$filename" || echo "File: $filename not formatted!" >> clang-format-report.txt
 done
 
 PAYLOAD_TIDY=`cat clang-tidy-report.txt`

--- a/runchecks.sh
+++ b/runchecks.sh
@@ -23,7 +23,6 @@ do
   is_supported=0
   for i in "${FILE_EXT_LIST[@]}"
   do
-    echo "testing ${URLS[index]} vs *$i"
     if [[ ${URLS[index]} == *".$i" ]]
     then
       is_supported=1

--- a/runchecks.sh
+++ b/runchecks.sh
@@ -34,7 +34,7 @@ do
   fi
 done
 
-echo "File names: $URLS"
+echo "File names: ${URLS[*]}"
 mkdir files
 cd files
 for i in "${URLS[@]}"


### PR DESCRIPTION
resolves #3 
This adds 2 new inputs to the action:
1. `style` can be set to any of the values that clang-format accepts. 
2. `extensions` a comma seperated list of file extensions for which to focus on. I added this one because I noticed the action was running clang-tidy/format on all changed files in the PR (which obviously resulted in more annoying failures and longer bot comments).

I can explain how the input args get passed to the run_checks.sh if needed.

I have also updated the Readme about the user inputs and required GH secrets token

-----------------------

## demo now lives here

I added a basic workflow using the action to test on a drafted PR since push events always fail with this action.