### PR TITLE
Output exit code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,12 @@ jobs:
     steps:
       # - uses: actions/checkout@v2
       - uses: shenxianpeng/cpp-linter-action@master
+        id: linter
         with:
           style: file
           extensions: 'cpp'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: steps.linter.checks-failed > 0
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fail fast?!
-        if: steps.linter.checks-failed > 0
+        if: steps.linter.outputs.checks-failed > 0
         run: |
           echo "Some files failed the linging checks!"
         # for actual deployment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Fail fast!
+      - name: Fail fast?!
         if: steps.linter.checks-failed > 0
-        run: exit 1
+        run: |
+          echo "Some files failed the linging checks!"
+        # for actual deployment
+        # run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # - uses: actions/checkout@v2
-      - uses: shenxianpeng/cpp-linter-action@master
+      # - uses: shenxianpeng/cpp-linter-action@master
+      - uses: 2bndy5/cpp-linter-action@output-exit-code
         id: linter
         with:
           style: file
@@ -15,5 +16,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - if: steps.linter.checks-failed > 0
+      - name: Fail fast!
+        if: steps.linter.checks-failed > 0
         run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # - uses: actions/checkout@v2
-      # - uses: shenxianpeng/cpp-linter-action@master
-      - uses: 2bndy5/cpp-linter-action@output-exit-code
+      - uses: shenxianpeng/cpp-linter-action@master
         id: linter
         with:
           style: file

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Fail fast?!
         if: steps.linter.outputs.checks-failed > 0
         run: |
-          echo "Some files failed the linging checks!"
+          echo "Some files failed the linting checks!"
         # for actual deployment
         # run: exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL com.github.actions.color="gray-dark"
 LABEL repository="https://github.com/shenxianpeng/cpp-linter-action"
 LABEL maintainer="shenxianpeng <20297606+shenxianpeng@users.noreply.github.com>"
 
-# RUN apt-get update
+RUN apt-get update
 RUN apt-get -y install curl jq
 
 COPY runchecks.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM xianpengshen/clang-tool
 
 LABEL com.github.actions.name="cpp-linter check"
 LABEL com.github.actions.description="Lint your code with clang-tidy in parallel to your builds"
@@ -8,9 +8,9 @@ LABEL com.github.actions.color="gray-dark"
 LABEL repository="https://github.com/shenxianpeng/cpp-linter-action"
 LABEL maintainer="shenxianpeng <20297606+shenxianpeng@users.noreply.github.com>"
 
-# WORKDIR /build
 RUN apt-get update
-RUN apt-get -y install curl clang-tidy cmake jq clang clang-format
+# RUN apt-get -y install curl clang-tidy cmake jq clang clang-format
+RUN apt-get -y install curl jq
 
 COPY runchecks.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ LABEL com.github.actions.color="gray-dark"
 LABEL repository="https://github.com/shenxianpeng/cpp-linter-action"
 LABEL maintainer="shenxianpeng <20297606+shenxianpeng@users.noreply.github.com>"
 
-RUN apt-get update
-# RUN apt-get -y install curl clang-tidy cmake jq clang clang-format
+# RUN apt-get update
 RUN apt-get -y install curl jq
 
 COPY runchecks.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ jobs:
 | style | 'llvm' | The style rules to use. Set this to 'file' to have clang-format use the closest relative .clang-format file. |
 | extensions | 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx' | The file extensions to run the action against. This is a comma-separated string. |
 
+### Outputs
+
+This action creates 1 output variable named `checks-failed`. Even if the linting checks fail for source files this action will still pass, but users' CI workflows can use this action's output to exit the workflow early if that is desired.
 ## Results of GitHub Actions
 
 Here is a test repository [cpp-linter-action-demo](https://github.com/shenxianpeng/cpp-linter-action-demo) which has added `cpp-linter.yml`. when an unformatted C/C++ source file was committed and create a Pull Request will automatically recognize and add warning comments.

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     default: "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx"
 outputs:
   checks-failed:
-    description: A an integer that can be used as a boolean value to indicate if all checks failed.
+    description: An integer that can be used as a boolean value to indicate if all checks failed.
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
     description: "The file extensions to run the action against. This comma-separated string defaults to 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'."
     required: false
     default: "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx"
+outputs:
+  checks-failed:
+    description: A an integer that can be used as a boolean value to indicate if all checks failed.
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/demo/.clang-tidy
+++ b/demo/.clang-tidy
@@ -1,0 +1,186 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,performance-*,bugprone-*,clang-analyzer-*,mpi-*,misc-*,readability-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     'file'
+CheckOptions:
+  - key:             bugprone-argument-comment.CommentBoolLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentCharacterLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentFloatLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentIntegerLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentNullPtrs
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentStringLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentUserDefinedLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.IgnoreSingleArgument
+    value:           '0'
+  - key:             bugprone-argument-comment.StrictMode
+    value:           '0'
+  - key:             bugprone-assert-side-effect.AssertMacros
+    value:           assert
+  - key:             bugprone-assert-side-effect.CheckFunctionCalls
+    value:           '0'
+  - key:             bugprone-dangling-handle.HandleClasses
+    value:           'std::basic_string_view;std::experimental::basic_string_view'
+  - key:             bugprone-dynamic-static-initializers.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             bugprone-exception-escape.FunctionsThatShouldNotThrow
+    value:           ''
+  - key:             bugprone-exception-escape.IgnoredExceptions
+    value:           ''
+  - key:             bugprone-misplaced-widening-cast.CheckImplicitCasts
+    value:           '0'
+  - key:             bugprone-not-null-terminated-result.WantToUseSafeFunctions
+    value:           '1'
+  - key:             bugprone-signed-char-misuse.CharTypdefsToIgnore
+    value:           ''
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfCompareToConstant
+    value:           '1'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfConstant
+    value:           '1'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfIntegerExpression
+    value:           '0'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfThis
+    value:           '1'
+  - key:             bugprone-string-constructor.LargeLengthThreshold
+    value:           '8388608'
+  - key:             bugprone-string-constructor.WarnOnLargeLength
+    value:           '1'
+  - key:             bugprone-suspicious-enum-usage.StrictMode
+    value:           '0'
+  - key:             bugprone-suspicious-missing-comma.MaxConcatenatedTokens
+    value:           '5'
+  - key:             bugprone-suspicious-missing-comma.RatioThreshold
+    value:           '0.200000'
+  - key:             bugprone-suspicious-missing-comma.SizeThreshold
+    value:           '5'
+  - key:             bugprone-suspicious-string-compare.StringCompareLikeFunctions
+    value:           ''
+  - key:             bugprone-suspicious-string-compare.WarnOnImplicitComparison
+    value:           '1'
+  - key:             bugprone-suspicious-string-compare.WarnOnLogicalNotComparison
+    value:           '0'
+  - key:             bugprone-too-small-loop-variable.MagnitudeBitsUpperLimit
+    value:           '16'
+  - key:             bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField
+    value:           '1'
+  - key:             bugprone-unused-return-value.CheckedFunctions
+    value:           '::std::async;::std::launder;::std::remove;::std::remove_if;::std::unique;::std::unique_ptr::release;::std::basic_string::empty;::std::vector::empty'
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           '0'
+  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value:           '1'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             misc-definitions-in-headers.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             misc-definitions-in-headers.UseHeaderFileExtension
+    value:           '1'
+  - key:             misc-throw-by-value-catch-by-reference.CheckThrowTemporaries
+    value:           '1'
+  - key:             misc-unused-parameters.StrictMode
+    value:           '0'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             performance-faster-string-find.StringLikeClasses
+    value:           'std::basic_string'
+  - key:             performance-for-range-copy.AllowedTypes
+    value:           ''
+  - key:             performance-for-range-copy.WarnOnAllAutoCopies
+    value:           '0'
+  - key:             performance-inefficient-string-concatenation.StrictMode
+    value:           '0'
+  - key:             performance-inefficient-vector-operation.EnableProto
+    value:           '0'
+  - key:             performance-inefficient-vector-operation.VectorLikeClasses
+    value:           '::std::vector'
+  - key:             performance-move-const-arg.CheckTriviallyCopyableMove
+    value:           '1'
+  - key:             performance-move-constructor-init.IncludeStyle
+    value:           llvm
+  - key:             performance-no-automatic-move.AllowedTypes
+    value:           ''
+  - key:             performance-type-promotion-in-math-fn.IncludeStyle
+    value:           llvm
+  - key:             performance-unnecessary-copy-initialization.AllowedTypes
+    value:           ''
+  - key:             performance-unnecessary-value-param.AllowedTypes
+    value:           ''
+  - key:             performance-unnecessary-value-param.IncludeStyle
+    value:           llvm
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           '0'
+  - key:             readability-else-after-return.WarnOnUnfixable
+    value:           '1'
+  - key:             readability-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.NestingThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.ParameterThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             readability-function-size.VariableThreshold
+    value:           '4294967295'
+  - key:             readability-identifier-naming.IgnoreFailedSplit
+    value:           '0'
+  - key:             readability-implicit-bool-conversion.AllowIntegerConditions
+    value:           '0'
+  - key:             readability-implicit-bool-conversion.AllowPointerConditions
+    value:           '0'
+  - key:             readability-inconsistent-declaration-parameter-name.IgnoreMacros
+    value:           '1'
+  - key:             readability-inconsistent-declaration-parameter-name.Strict
+    value:           '0'
+  - key:             readability-magic-numbers.IgnoredFloatingPointValues
+    value:           '1.0;100.0;'
+  - key:             readability-magic-numbers.IgnoredIntegerValues
+    value:           '1;2;3;4;'
+  - key:             readability-redundant-member-init.IgnoreBaseInCopyConstructors
+    value:           '0'
+  - key:             readability-redundant-smartptr-get.IgnoreMacros
+    value:           '1'
+  - key:             readability-redundant-string-init.StringNames
+    value:           '::std::basic_string'
+  - key:             readability-simplify-boolean-expr.ChainedConditionalAssignment
+    value:           '0'
+  - key:             readability-simplify-boolean-expr.ChainedConditionalReturn
+    value:           '0'
+  - key:             readability-simplify-subscript-expr.Types
+    value:           '::std::basic_string;::std::basic_string_view;::std::vector;::std::array'
+  - key:             readability-static-accessed-through-instance.NameSpecifierNestingThreshold
+    value:           '3'
+  - key:             readability-uppercase-literal-suffix.IgnoreMacros
+    value:           '1'
+  - key:             readability-uppercase-literal-suffix.NewSuffixes
+    value:           ''
+...

--- a/demo/demo.cpp
+++ b/demo/demo.cpp
@@ -1,4 +1,4 @@
-/** This is an very ugly test code (doomed to fail linting) */
+/** This is a very ugly test code (doomed to fail linting) */
 
 #include <stdio.h>
 

--- a/demo/demo.cpp
+++ b/demo/demo.cpp
@@ -1,3 +1,4 @@
+/** This is an very ugly test code (doomed to fail linting) */
 
 #include <stdio.h>
 
@@ -6,10 +7,8 @@
 
 int main(){
 
+    for (;;) break;
+
     printf("Hello world!\n");
 
     return 0;}
-
-
-
-/* This is an ugly test code */

--- a/runchecks.sh
+++ b/runchecks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-EXIT_CODE=0
+EXIT_CODE="0"
 PAYLOAD_FORMAT=""
 PAYLOAD_TIDY=""
 
@@ -11,7 +11,7 @@ function set_exit_code () {
    else
       if [ "$PAYLOAD_FORMAT" != "" && "$PAYLOAD_TIDY" != "" ]
       then
-         EXIT_CODE=1
+         EXIT_CODE="1"
       fi
    fi
    echo "exit code = $EXIT_CODE"

--- a/runchecks.sh
+++ b/runchecks.sh
@@ -4,7 +4,7 @@ EXIT_CODE=0
 PAYLOAD_FORMAT=""
 PAYLOAD_TIDY=""
 
-function set_exit_code {
+function set_exit_code () {
    if [ $# > 1 ]
    then
       EXIT_CODE="$1"
@@ -22,7 +22,7 @@ function set_exit_code {
 if [[ -z "$GITHUB_TOKEN" ]]
 then
 	echo "The GITHUB_TOKEN is required."
-   set_exit_code(1)
+   set_exit_code "1"
 	exit $EXIT_CODE
 fi
 
@@ -60,7 +60,7 @@ done
 # exit early if nothing to do
 if [ "${URLS[#]}" == 0 ]
 then
-   set_exit_code(0)
+   set_exit_code "0"
    echo "No source files need checking!"
    exit $EXIT_CODE
 else
@@ -115,4 +115,5 @@ echo "OUTPUT is: \n $OUTPUT"
 PAYLOAD=$(echo '{}' | jq --arg body "$OUTPUT" '.body = $body')
 
 curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/vnd.github.VERSION.text+json" --data "$PAYLOAD" "$COMMENTS_URL"
-set_exit_code()
+
+set_exit_code

--- a/runchecks.sh
+++ b/runchecks.sh
@@ -1,20 +1,43 @@
 #!/bin/bash
 
-if [[ -z "$GITHUB_TOKEN" ]]; then
+EXIT_CODE=0
+PAYLOAD_FORMAT=""
+PAYLOAD_TIDY=""
+
+function set_exit_code {
+   if [ $# > 1 ]
+   then
+      EXIT_CODE="$1"
+   else
+      if [ "$PAYLOAD_FORMAT" != "" && "$PAYLOAD_TIDY" != "" ]
+      then
+         EXIT_CODE=1
+      fi
+   fi
+
+   echo "::set-output name=checks-failed::$(echo $EXIT_CODE)"
+}
+
+# check for access token (ENV VAR needed for git API calls)
+if [[ -z "$GITHUB_TOKEN" ]]
+then
 	echo "The GITHUB_TOKEN is required."
-	exit 1
+   set_exit_code(1)
+	exit $EXIT_CODE
 fi
 
+# parse CLI args
 args=("$@")
 FMT_STYLE=${args[0]}
 IFS=',' read -r -a FILE_EXT_LIST <<< "${args[1]}"
 
+# use git API payload
 FILES_LINK=`jq -r '.pull_request._links.self.href' "$GITHUB_EVENT_PATH"`/files
 echo "Files = $FILES_LINK"
 
+# setup download URLS
 curl $FILES_LINK > files.json
 FILES_URLS_STRING=`jq -r '.[].raw_url' files.json`
-
 readarray -t URLS <<<"$FILES_URLS_STRING"
 
 # exclude undesired files
@@ -34,7 +57,16 @@ do
   fi
 done
 
-echo "File names: ${URLS[*]}"
+# exit early if nothing to do
+if [ "${URLS[#]}" == 0 ]
+then
+   set_exit_code(0)
+   echo "No source files need checking!"
+   exit $EXIT_CODE
+else
+   echo "File names: ${URLS[*]}"
+fi
+
 mkdir files
 cd files
 for i in "${URLS[@]}"
@@ -83,11 +115,4 @@ echo "OUTPUT is: \n $OUTPUT"
 PAYLOAD=$(echo '{}' | jq --arg body "$OUTPUT" '.body = $body')
 
 curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/vnd.github.VERSION.text+json" --data "$PAYLOAD" "$COMMENTS_URL"
-
-EXIT_CODE=0
-if [ "$PAYLOAD_FORMAT" != "" && "$PAYLOAD_TIDY" != "" ]
-then
-  EXIT_CODE=1
-fi
-
-echo "::set-output name=checks-failed::$(echo $EXIT_CODE)"
+set_exit_code()

--- a/runchecks.sh
+++ b/runchecks.sh
@@ -5,7 +5,7 @@ PAYLOAD_FORMAT=""
 PAYLOAD_TIDY=""
 
 function set_exit_code () {
-   if [ $# > 0 ]
+   if [[ $# -gt 0 ]]
    then
       EXIT_CODE="$1"
    else
@@ -23,7 +23,7 @@ if [[ -z "$GITHUB_TOKEN" ]]
 then
 	echo "The GITHUB_TOKEN is required."
    set_exit_code "1"
-	exit $EXIT_CODE
+	exit "$EXIT_CODE"
 fi
 
 # parse CLI args

--- a/runchecks.sh
+++ b/runchecks.sh
@@ -58,7 +58,7 @@ do
 done
 
 # exit early if nothing to do
-if [ "${URLS[#]}" == 0 ]
+if [ ${#URLS[@]} == 0 ]
 then
    set_exit_code "0"
    echo "No source files need checking!"

--- a/runchecks.sh
+++ b/runchecks.sh
@@ -9,12 +9,11 @@ function set_exit_code () {
    then
       EXIT_CODE="$1"
    else
-      if [ "$PAYLOAD_FORMAT" != "" && "$PAYLOAD_TIDY" != "" ]
+      if [[ "$PAYLOAD_FORMAT" != "" || "$PAYLOAD_TIDY" != "" ]]
       then
          EXIT_CODE="1"
       fi
    fi
-   echo "exit code = $EXIT_CODE"
    echo "::set-output name=checks-failed::$(echo $EXIT_CODE)"
 }
 

--- a/runchecks.sh
+++ b/runchecks.sh
@@ -83,3 +83,11 @@ echo "OUTPUT is: \n $OUTPUT"
 PAYLOAD=$(echo '{}' | jq --arg body "$OUTPUT" '.body = $body')
 
 curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/vnd.github.VERSION.text+json" --data "$PAYLOAD" "$COMMENTS_URL"
+
+EXIT_CODE=0
+if [ "$PAYLOAD_FORMAT" != "" && "$PAYLOAD_TIDY" != "" ]
+then
+  EXIT_CODE=1
+fi
+
+echo "::set-output name=checks-failed::$(echo $EXIT_CODE)"

--- a/runchecks.sh
+++ b/runchecks.sh
@@ -5,7 +5,7 @@ PAYLOAD_FORMAT=""
 PAYLOAD_TIDY=""
 
 function set_exit_code () {
-   if [ $# > 1 ]
+   if [ $# > 0 ]
    then
       EXIT_CODE="$1"
    else
@@ -110,10 +110,10 @@ if [ "$PAYLOAD_FORMAT" != "" ]; then
    OUTPUT+=$'\n```\n'
 fi
 
+set_exit_code
+
 echo "OUTPUT is: \n $OUTPUT"
 
 PAYLOAD=$(echo '{}' | jq --arg body "$OUTPUT" '.body = $body')
 
 curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/vnd.github.VERSION.text+json" --data "$PAYLOAD" "$COMMENTS_URL"
-
-set_exit_code

--- a/runchecks.sh
+++ b/runchecks.sh
@@ -14,7 +14,7 @@ function set_exit_code () {
          EXIT_CODE=1
       fi
    fi
-
+   echo "exit code = $EXIT_CODE"
    echo "::set-output name=checks-failed::$(echo $EXIT_CODE)"
 }
 

--- a/runchecks.sh
+++ b/runchecks.sh
@@ -14,7 +14,7 @@ function set_exit_code () {
          EXIT_CODE="1"
       fi
    fi
-   echo "::set-output name=checks-failed::$(echo $EXIT_CODE)"
+   echo "::set-output name=checks-failed::$EXIT_CODE"
 }
 
 # check for access token (ENV VAR needed for git API calls)


### PR DESCRIPTION
resolves #7 
- added a step to the test.yml so it `echo`s the new output but the action doesn't fail if the checks fail.
- also used this chance to exit the run_checks.sh script early if no files need to be checked.
- switched Docker container to shenxianpeng/clang-tools which saves a significant amount of setup time
   - I also removed Dockerfile's CMD to install CMake (wasn't ever needed) and clang* tools that are now provided by docker image.

NOTE: the output code is automatically removed from the logs, so we won't actually see the text
```
::set-output name=checks-failed::<EXIT_CODE>
```