### PR TITLE
#12 support dynamic tags in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM xianpengshen/clang-tools:11
+ARG TAG=latest
+FROM xianpengshen/clang-tools:$TAG
 
 LABEL com.github.actions.name="cpp-linter check"
 LABEL com.github.actions.description="Lint your code with clang-tidy in parallel to your builds"


### PR DESCRIPTION
Here are the test outputs:
```bash
$ docker build -t mylinter .
Sending build context to Docker daemon  157.7kB
Step 1/13 : ARG TAG=latest
Step 2/13 : FROM xianpengshen/clang-tools:$TAG
latest: Pulling from xianpengshen/clang-tools
16ec32c2132b: Already exists 
5060a1b0a7b4: Pull complete 
7c2e2988991f: Pull complete 
0e88c4ace6b5: Pull complete 
359b8333a1fd: Pull complete 
Digest: sha256:4764203ceb91d398c2e54f8b342b6e1fbb5bdc12c0af160d8c1061a5b94f14e4
Status: Downloaded newer image for xianpengshen/clang-tools:latest
```

```bash
$ docker build -t mylinter --build-arg TAG=11 .
Sending build context to Docker daemon    148kB
Step 1/13 : ARG TAG=latest
Step 2/13 : FROM xianpengshen/clang-tools:$TAG
11: Pulling from xianpengshen/clang-tools
16ec32c2132b: Already exists 
9ab7b46a9274: Already exists 
874d7be7aeff: Already exists 
946288b196e8: Already exists 
f9fe9aeb80ff: Already exists 
Digest: sha256:83a8b7cc7ff77bcaf1c25c3e70a7f581b336e3284cb1ba6dfeba87b0e400f3c4
Status: Downloaded newer image for xianpengshen/clang-tools:11
```

