### PR TITLE
Update Mkdocs

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -2,8 +2,8 @@ name: MkDocs Deploy
 
 on:
   push:
-    branches: [ master ]
-    paths: 
+    branches: [master]
+    paths:
       - 'docs/**'
   workflow_dispatch:
 

--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -1,0 +1,22 @@
+name: MkDocs Deploy
+
+on:
+  push:
+    branches: [ master ]
+    paths: 
+      - 'docs/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - run: pip install -r docs/requirements.txt
+      - run: |
+          git config user.name 'github-actions'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          mkdocs gh-deploy --force

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,5 @@
 ## How to build the docs
+
 From the root directory of the repository, do the following to steps
 
 1. Install docs' dependencies

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,3 @@
    start="<!--footer-start-->"
    end="<!--footer-end-->"
 %}
-{%
-   include-markdown "README.md"
-%}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: C/C++ Linter Action's Docs
+site_name: C/C++ Linter Action
 site_description: "Developer documentation from sources."
 site_url: "https://shenxianpeng.github.io/cpp-linter-action"
 repo_url: "https://github.com/shenxianpeng/cpp-linter-action"


### PR DESCRIPTION
Hi @2bndy5 I did a little change to your awesome contribution, let me know if any comments. Thank you.

* Remove [How to build the docs](https://cpp-linter-action.readthedocs.io/en/latest/?badge=latest#how-to-build-the-docs) section from Home (users may not need to know how to build documentation)
* Changed "C/C++ Linter Action's Docs" to "C/C++ Linter Action", this would look simpler and shorter.

