### PR TITLE
Private repo support

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -395,7 +395,7 @@ valid-metaclass-classmethod-first-arg=mcs
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=5
+max-args=8
 
 # Maximum number of attributes for a class (see R0902).
 # max-attributes=7

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,7 @@ LABEL com.github.actions.color="gray-dark"
 LABEL repository="https://github.com/shenxianpeng/cpp-linter-action"
 LABEL maintainer="shenxianpeng <20297606+shenxianpeng@users.noreply.github.com>"
 
-RUN apt-get update
-RUN apt-get -y install python3-pip
-# RUN python3 -m pip install --upgrade pip
+RUN apt-get update && apt-get -y install python3-pip
 
 COPY cpp_linter/ pkg/cpp_linter/
 COPY setup.py pkg/setup.py

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ jobs:
 
 - **Description**: Set this option to false to analyze any source files in the repo.
 - Default: true
+- NOTE: The `GITHUB_TOKEN` should be supplied when running on a private repository with this option enabled, otherwise the runner does not not have the privilege to list changed files for an event. See [Authenticating with the GITHUB_TOKEN](https://docs.github.com/en/actions/reference/authentication-in-a-workflow)
 
 #### `ignore`
 
@@ -115,6 +116,7 @@ jobs:
   - To use thread comments, the `GITHUB_TOKEN` (provided by Github to each repository) must be declared as an environment
     variable. See [Authenticating with the GITHUB_TOKEN](https://docs.github.com/en/actions/reference/authentication-in-a-workflow)
 - Default: true
+- NOTE: If run on a private repository, then this feature is disabled because the GitHub REST API behaves differently for thread comments on a private repository.
 
 #### `database`
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ jobs:
 
 #### `version`
 
-- **Description**: The desired version of the clang tools to use. Accepted options are strings which can be 6.0, 7, 8, 9, 10, 11, or 12.
+- **Description**: The desired version of the [clang-tools](https://hub.docker.com/repository/docker/xianpengshen/clang-tools) to use. Accepted options are strings which can be 6.0, 7, 8, 9, 10, 11, 12 or 13.
 - Default: '10'
 
 #### `verbosity`

--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ jobs:
 
 #### `lines-changed-only`
 
-- **Description**: Set this option to true to only analyse changes in the event's diff.
+- **Description**: Set this option to true to only analyze changes in the event's diff.
 - Default: false
 
 #### `files-changed-only`
 
-- **Description**: Set this option to false to analyse any source files in the repo.
+- **Description**: Set this option to false to analyze any source files in the repo.
 - Default: true
 
 #### `ignore`
@@ -106,7 +106,7 @@ jobs:
   - Prefix a path with a bang ('!') to make it explicitly _not_ ignored - order of
     multiple paths does _not_ take precedence. The '!' prefix can be applied to
     a submodule's path (if desired) but not hidden directories.
-  - Glob patterns are not supported here. All asterick characters ('\*') are literal.
+  - Glob patterns are not supported here. All asterisk characters ('\*') are literal.
 - Default: '.github'
 
 #### `thread-comments`
@@ -115,6 +115,11 @@ jobs:
   - To use thread comments, the `GITHUB_TOKEN` (provided by Github to each repository) must be declared as an environment
     variable. See [Authenticating with the GITHUB_TOKEN](https://docs.github.com/en/actions/reference/authentication-in-a-workflow)
 - Default: true
+
+#### `database`
+
+- **Description**: The directory containing compilation database (like compile_commands.json) file.
+- Default: ''
 
 ### Outputs
 
@@ -140,7 +145,7 @@ You can show C/C++ Lint Action status with a badge in your repository README
 
 Example
 
-```
+```markdown
 [![cpp-linter](https://github.com/shenxianpeng/cpp-linter-action/actions/workflows/cpp-linter.yml/badge.svg)](https://github.com/shenxianpeng/cpp-linter-action/actions/workflows/cpp-linter.yml)
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -63,9 +63,13 @@ inputs:
       - Prefix a path with a bang (`!`) to make it explicitly not ignored - order of
         multiple paths does take precedence. The `!` prefix can be applied to
         submodules if desired.
-      - Glob patterns are not supported here. All asterick characters ('*') are literal.
+      - Glob patterns are not supported here. All asterisk characters ('*') are literal.
     required: false
     default: ".github"
+  database:
+    description: The directory containing compile_commands.json file.
+    required: false
+    default: ""
 outputs:
   checks-failed:
     description: An integer that can be used as a boolean value to indicate if all checks failed.
@@ -82,5 +86,5 @@ runs:
     - --lines-changed-only=${{ inputs.lines-changed-only }}
     - --files-changed-only=${{ inputs.files-changed-only }}
     - --thread-comments=${{ inputs.thread-comments }}
-    - --ignore
-    - ${{ inputs.ignore }}
+    - --ignore=${{ inputs.ignore }}
+    - --database=${{ inputs.database }}

--- a/cpp_linter/__init__.py
+++ b/cpp_linter/__init__.py
@@ -27,10 +27,10 @@ if not FOUND_RICH_LIB:
 GITHUB_SHA = os.getenv("GITHUB_SHA", "")
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", os.getenv("GIT_REST_API", ""))
 API_HEADERS = {
-    "Authorization": f"token {GITHUB_TOKEN}",
     "Accept": "application/vnd.github.v3.text+json",
 }
-
+if GITHUB_TOKEN:
+    API_HEADERS["Authorization"] = f"token {GITHUB_TOKEN}"
 
 class Globals:
     """Global variables for re-use (non-constant)."""
@@ -40,7 +40,7 @@ class Globals:
     OUTPUT = ""
     """The accumulated body of the resulting comment that gets posted."""
     FILES = []
-    """The reponding payload containing info about changed files."""
+    """The responding payload containing info about changed files."""
     EVENT_PAYLOAD = {}
     """The parsed JSON of the event payload."""
     response_buffer = None

--- a/cpp_linter/__init__.py
+++ b/cpp_linter/__init__.py
@@ -3,6 +3,7 @@ multiple modules."""
 import io
 import os
 import logging
+from requests import Response
 
 FOUND_RICH_LIB = False
 try:
@@ -41,7 +42,7 @@ class Globals:
     """The responding payload containing info about changed files."""
     EVENT_PAYLOAD = {}
     """The parsed JSON of the event payload."""
-    response_buffer = None
+    response_buffer = Response()
     """A shared response object for `requests` module."""
 
 

--- a/cpp_linter/__init__.py
+++ b/cpp_linter/__init__.py
@@ -26,9 +26,7 @@ if not FOUND_RICH_LIB:
 # global constant variables
 GITHUB_SHA = os.getenv("GITHUB_SHA", "")
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", os.getenv("GIT_REST_API", ""))
-API_HEADERS = {
-    "Accept": "application/vnd.github.v3.text+json",
-}
+API_HEADERS = {"Accept": "application/vnd.github.v3.text+json",}
 if GITHUB_TOKEN:
     API_HEADERS["Authorization"] = f"token {GITHUB_TOKEN}"
 

--- a/cpp_linter/__init__.py
+++ b/cpp_linter/__init__.py
@@ -91,7 +91,17 @@ def get_line_cnt_from_cols(file_path: str, offset: int) -> tuple:
     return (line_cnt, cols)
 
 
-def log_response_msg():
-    """Output the response buffer's message on a failed request."""
+def log_response_msg() -> bool:
+    """Output the response buffer's message on a failed request.
+
+    Returns:
+        A bool decribing if response's status code was less than 400.
+    """
     if Globals.response_buffer.status_code >= 400:
-        logger.error("response returned message: %s", Globals.response_buffer.text)
+        logger.error(
+            "response returned %d message: %s",
+            Globals.response_buffer.status_code,
+            Globals.response_buffer.text,
+        )
+        return False
+    return True

--- a/cpp_linter/clang_tidy_yml.py
+++ b/cpp_linter/clang_tidy_yml.py
@@ -4,9 +4,9 @@ import yaml
 from . import GlobalParser, get_line_cnt_from_cols
 
 
-CWD_HEADER_GAURD = bytes(
+CWD_HEADER_GUARD = bytes(
     os.getcwd().upper().replace(os.sep, "_").replace("-", "_"), encoding="utf-8"
-)  #: The constant used to trim absolute paths from header gaurd suggestions.
+)  #: The constant used to trim absolute paths from header guard suggestions.
 
 
 class TidyDiagnostic:
@@ -121,10 +121,10 @@ def parse_tidy_suggestions_yml():
                 print(
                     "filtering header guard suggestion (making relative to repo root)"
                 )
-                fix.text = fix.text.replace(CWD_HEADER_GAURD, b"")
+                fix.text = fix.text.replace(CWD_HEADER_GUARD, b"")
             diag.replacements.append(fix)
         fixit.diagnostics.append(diag)
-        # filter out absolute header gaurds
+        # filter out absolute header guards
     GlobalParser.tidy_advice.append(fixit)
 
 

--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -35,7 +35,7 @@ from .thread_comments import remove_bot_comments, list_diff_comments  # , get_re
 
 
 # global constant variables
-GITHUB_EVEN_PATH = os.getenv("GITHUB_EVENT_PATH", "")
+GITHUB_EVENT_PATH = os.getenv("GITHUB_EVENT_PATH", "")
 GITHUB_API_URL = os.getenv("GITHUB_API_URL", "https://api.github.com")
 GITHUB_REPOSITORY = os.getenv("GITHUB_REPOSITORY", "")
 GITHUB_EVENT_NAME = os.getenv("GITHUB_EVENT_NAME", "unknown")
@@ -770,7 +770,7 @@ def main():
         end_log_group()
 
     exit_early = False
-    with open(GITHUB_EVEN_PATH, "r", encoding="utf-8") as payload:
+    with open(GITHUB_EVENT_PATH, "r", encoding="utf-8") as payload:
         Globals.EVENT_PAYLOAD = json.load(payload)
     if logger.getEffectiveLevel() <= logging.DEBUG:
         start_log_group("Event json from the runner")
@@ -802,7 +802,12 @@ def main():
     )
 
     start_log_group("Posting comment(s)")
-    if args.thread_comments:
+    thread_comments_allowed = True
+    if "private" in Globals.EVENT_PAYLOAD["repository"]:
+        thread_comments_allowed = (
+            Globals.EVENT_PAYLOAD["repository"]["private"] != "true"
+        )
+    if args.thread_comments and thread_comments_allowed:
         post_results(False)  # False is hard-coded to disable diff comments.
     set_exit_code(int(make_annotations(args.style)))
     end_log_group()

--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -211,7 +211,7 @@ def get_list_of_changed_files() -> None:
         logger.warning("triggered on unsupported event.")
         sys.exit(set_exit_code(0))
     logger.info("Fetching files list from url: %s", files_link)
-    Globals.FILES = requests.get(files_link).json()
+    Globals.FILES = requests.get(files_link, headers=API_HEADERS).json()
 
 
 def filter_out_non_source_files(

--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -770,12 +770,6 @@ def main():
         end_log_group()
 
     exit_early = False
-    with open(GITHUB_EVENT_PATH, "r", encoding="utf-8") as payload:
-        Globals.EVENT_PAYLOAD = json.load(payload)
-    if logger.getEffectiveLevel() <= logging.DEBUG:
-        start_log_group("Event json from the runner")
-        logger.debug(json.dumps(Globals.EVENT_PAYLOAD))
-        end_log_group()
     if args.files_changed_only:
         get_list_of_changed_files()
         exit_early = not filter_out_non_source_files(

--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -761,6 +761,14 @@ def main():
     # change working directory
     os.chdir(args.repo_root)
 
+    # load event's json info about the workflow run
+    with open(GITHUB_EVEN_PATH, "r", encoding="utf-8") as payload:
+        Globals.EVENT_PAYLOAD = json.load(payload)
+    if logger.getEffectiveLevel() <= logging.DEBUG:
+        start_log_group("Event json from the runner")
+        logger.debug(json.dumps(Globals.EVENT_PAYLOAD))
+        end_log_group()
+
     exit_early = False
     with open(GITHUB_EVEN_PATH, "r", encoding="utf-8") as payload:
         Globals.EVENT_PAYLOAD = json.load(payload)
@@ -769,7 +777,6 @@ def main():
         logger.debug(json.dumps(Globals.EVENT_PAYLOAD))
         end_log_group()
     if args.files_changed_only:
-        # load event's json info about the workflow run
         get_list_of_changed_files()
         exit_early = not filter_out_non_source_files(
             args.extensions,

--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -805,7 +805,7 @@ def main():
     thread_comments_allowed = True
     if "private" in Globals.EVENT_PAYLOAD["repository"]:
         thread_comments_allowed = (
-            Globals.EVENT_PAYLOAD["repository"]["private"] != True
+            Globals.EVENT_PAYLOAD["repository"]["private"] is not True
         )
     if args.thread_comments and thread_comments_allowed:
         post_results(False)  # False is hard-coded to disable diff comments.

--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -762,7 +762,7 @@ def main():
     os.chdir(args.repo_root)
 
     # load event's json info about the workflow run
-    with open(GITHUB_EVEN_PATH, "r", encoding="utf-8") as payload:
+    with open(GITHUB_EVENT_PATH, "r", encoding="utf-8") as payload:
         Globals.EVENT_PAYLOAD = json.load(payload)
     if logger.getEffectiveLevel() <= logging.DEBUG:
         start_log_group("Event json from the runner")

--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -805,7 +805,7 @@ def main():
     thread_comments_allowed = True
     if "private" in Globals.EVENT_PAYLOAD["repository"]:
         thread_comments_allowed = (
-            Globals.EVENT_PAYLOAD["repository"]["private"] != "true"
+            Globals.EVENT_PAYLOAD["repository"]["private"] != True
         )
     if args.thread_comments and thread_comments_allowed:
         post_results(False)  # False is hard-coded to disable diff comments.

--- a/cpp_linter/thread_comments.py
+++ b/cpp_linter/thread_comments.py
@@ -16,8 +16,9 @@ def remove_bot_comments(comments_url: str, user_id: int):
     """
     logger.info("comments_url: %s", comments_url)
     Globals.response_buffer = requests.get(comments_url)
+    log_response_msg()
     comments = Globals.response_buffer.json()
-    for i, comment in enumerate(comments):
+    for comment in comments:
         # only search for comments from the user's ID and
         # whose comment body begins with a specific html comment
         if (
@@ -36,7 +37,6 @@ def remove_bot_comments(comments_url: str, user_id: int):
                 comment["url"][comment["url"].find(".com") + 4 :],
             )
             log_response_msg()
-            del comments[i]
         logger.debug(
             "comment id %d from user %s (%d)",
             comment["id"],

--- a/cpp_linter/thread_comments.py
+++ b/cpp_linter/thread_comments.py
@@ -18,7 +18,7 @@ def remove_bot_comments(comments_url: str, user_id: int):
     Globals.response_buffer = requests.get(comments_url)
     comments = Globals.response_buffer.json()
     for i, comment in enumerate(comments):
-        # only serach for comments from the user's ID and
+        # only search for comments from the user's ID and
         # whose comment body begins with a specific html comment
         if (
             int(comment["user"]["id"]) == user_id
@@ -231,7 +231,7 @@ def get_review_id(reviews_url: str, user_id: int) -> int:
         Globals.response_buffer = requests.get(reviews_url)
         if Globals.response_buffer.status_code != 200:
             log_response_msg()
-            raise RuntimeError("could not create a review for commemts")
+            raise RuntimeError("could not create a review for comments")
         reviews = json.loads(Globals.response_buffer.text)
         reviews.reverse()  # traverse the list in reverse
         review_id = find_review(reviews, user_id)

--- a/cpp_linter/thread_comments.py
+++ b/cpp_linter/thread_comments.py
@@ -15,7 +15,10 @@ def remove_bot_comments(comments_url: str, user_id: int):
         user_id: The user's account id number.
     """
     logger.info("comments_url: %s", comments_url)
-    Globals.response_buffer = requests.get(comments_url)
+    Globals.response_buffer = requests.get(
+        comments_url,
+        headers={"Accept": "application/vnd.github.v3.text+json"},
+    )
     if not log_response_msg():
         return  # error getting comments for the thread; stop here
     comments = Globals.response_buffer.json()

--- a/cpp_linter/thread_comments.py
+++ b/cpp_linter/thread_comments.py
@@ -15,10 +15,7 @@ def remove_bot_comments(comments_url: str, user_id: int):
         user_id: The user's account id number.
     """
     logger.info("comments_url: %s", comments_url)
-    Globals.response_buffer = requests.get(
-        comments_url,
-        headers={"Accept": "application/vnd.github.v3.text+json"},
-    )
+    Globals.response_buffer = requests.get(comments_url, headers=API_HEADERS)
     if not log_response_msg():
         return  # error getting comments for the thread; stop here
     comments = Globals.response_buffer.json()

--- a/cpp_linter/thread_comments.py
+++ b/cpp_linter/thread_comments.py
@@ -16,7 +16,8 @@ def remove_bot_comments(comments_url: str, user_id: int):
     """
     logger.info("comments_url: %s", comments_url)
     Globals.response_buffer = requests.get(comments_url)
-    log_response_msg()
+    if not log_response_msg():
+        return  # error getting comments for the thread; stop here
     comments = Globals.response_buffer.json()
     for comment in comments:
         # only search for comments from the user's ID and
@@ -229,8 +230,7 @@ def get_review_id(reviews_url: str, user_id: int) -> int:
             Globals.response_buffer.status_code,
         )
         Globals.response_buffer = requests.get(reviews_url)
-        if Globals.response_buffer.status_code != 200:
-            log_response_msg()
+        if Globals.response_buffer.status_code != 200 and log_response_msg():
             raise RuntimeError("could not create a review for comments")
         reviews = json.loads(Globals.response_buffer.text)
         reviews.reverse()  # traverse the list in reverse

--- a/demo/demo.cpp
+++ b/demo/demo.cpp
@@ -1,16 +1,16 @@
 /** This is a very ugly test code (doomed to fail linting) */
 #include "demo.hpp"
-#include <stdio.h> ///
+#include <stdio.h>
 
 
 
 
 int main(){
 
-    for (;;) break; ///
+    for (;;) break;
 
 
-    printf("Hello world!\n");  ///
+    printf("Hello world!\n");
 
 
 

--- a/demo/demo.hpp
+++ b/demo/demo.hpp
@@ -8,7 +8,7 @@ class Dummy {
     Dummy() :numb(0), useless("\0"){}
 
     public:
-    void *not_usefull(char *str){useless = str;} ///
+    void *not_usefull(char *str){useless = str;}
 };
 
 
@@ -31,6 +31,6 @@ class Dummy {
 struct LongDiff
 {
 
-    long diff; ///
+    long diff;
 
 };


### PR DESCRIPTION
Use `Accept` arg in the header of the `requests` call to get a list of changed files. If a token is supplied, then it is included in the header's `Authorization` arg. This idea might be applicable to all REST API calls, but for security reasons (and I haven't verified with the REST API docs), it is only applied to the `get_list_of_changed_files()`.

~I'm not confident, but I think~ this should address #38 

---
I have recently started using a [VSCode extension that checks spelling](https://github.com/streetsidesoftware/vscode-spell-checker). So, I also fixed some spelling errors in the python source code.
