### PR TITLE
better consideration for windows-based runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ jobs:
 
       - name: run linter as a python package
         id: linter
-        # pass the installed path (with '/bin' appended) to the '--version' argument
-        run: cpp-linter --version=${{ runner.temp }}/llvm/bin
+        # pass the installed path to the '--version' argument
+        run: cpp-linter --version=${{ runner.temp }}/llvm
 
       - name: Fail fast?!
         if: steps.linter.outputs.checks-failed > 0

--- a/README.md
+++ b/README.md
@@ -128,6 +128,57 @@ jobs:
 
 This action creates 1 output variable named `checks-failed`. Even if the linting checks fail for source files this action will still pass, but users' CI workflows can use this action's output to exit the workflow early if that is desired.
 
+## Using a Windows-based runner
+
+This action can only be run on a runner using the Ubuntu Operating System. However, this action's source code (essentially a python package) can be used on a runner using the Windows Operating System.
+
+Note: MacOS-based runners have not been tested, but the same approach applies.
+
+This example makes use of another action
+([KyleMayes/install-llvm-action](https://github.com/KyleMayes/install-llvm-action))
+to install a certain version of clang-tidy and clang-format.
+
+```yml
+on:
+  push:
+    paths-ignore: "docs/**"
+  pull_request:
+    paths-ignore: "docs/**"
+
+jobs:
+  cpp-linter:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+
+      - name: Install clang-tools
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          # v12 is the recommended minimum for the Visual Studio compiler
+          version: 12
+          # specifying an install path is required because
+          # Windows runners already have a certain version of LLVM installed
+          directory: ${{ runner.temp }}/llvm
+
+      - name: Install linter python package
+        run: python3 -m pip install git+https://github.com/shenxianpeng/cpp-linter-action
+
+      - name: run linter as a python package
+        id: linter
+        # pass the installed path (with '/bin' appended) to the '--version' argument
+        run: cpp-linter --version=${{ runner.temp }}/llvm/bin
+
+      - name: Fail fast?!
+        if: steps.linter.outputs.checks-failed > 0
+        run: echo "Some files failed the linting checks!"
+        # for actual deployment
+        # run: exit 1
+```
+
+All input options listed above are specified by pre-pending a `--`. You can also install this repo locally and run `cpp-linter -h` for more detail.
+
 ## Example
 
 <!--intro-end-->

--- a/cpp_linter/__init__.py
+++ b/cpp_linter/__init__.py
@@ -25,6 +25,7 @@ if not FOUND_RICH_LIB:
     logger.debug("rich module not found")
 
 # global constant variables
+IS_ON_RUNNER = bool(os.getenv("CI"))
 GITHUB_SHA = os.getenv("GITHUB_SHA", "")
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", os.getenv("GIT_REST_API", ""))
 API_HEADERS = {"Accept": "application/vnd.github.v3.text+json",}

--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -84,7 +84,8 @@ cli_arg_parser.add_argument(
     "--version",
     default="10",
     help="The desired version of the clang tools to use. Accepted options are strings "
-    "which can be 6.0, 7, 8, 9, 10, 11, 12. Defaults to %(default)s.",
+    "which can be 6.0, 7, 8, 9, 10, 11, 12. Defaults to %(default)s. On Windows, this "
+    "can also be a path to the install location of LLVM",
 )
 cli_arg_parser.add_argument(
     "-e",
@@ -107,7 +108,7 @@ cli_arg_parser.add_argument(
     help="Set this option with paths to ignore. In the case of multiple "
     "paths, you can set this option (multiple times) for each path. This can "
     "also have files, but the file's relative path has to be specified as well "
-    "with the filename.",
+    "with the filename. Prefix a path with '!' to explicitly not ignore it.",
 )
 cli_arg_parser.add_argument(
     "--lines-changed-only",

--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -396,6 +396,9 @@ def run_clang_tidy(
         cmds = ["clang-tidy"]
         if os.path.exists(version):
             cmds = [f"{version}\\clang-tidy.exe"]
+    elif not version.isdigit():
+        logger.warning("ignoring invalid version number %s.", version)
+        cmds = ["clang-tidy"]
     if checks:
         cmds.append(f"-checks={checks}")
     cmds.append("--export-fixes=clang_tidy_output.yml")
@@ -442,13 +445,17 @@ def run_clang_format(
         lines_changed_only: A flag that forces focus on only changes in the event's
             diff info.
     """
+    is_on_windows = sys.platform.startswith("win32")
     cmds = [
-        "clang-format" + ("" if sys.platform.startswith("win32") else f"-{version}"),
+        "clang-format" + ("" if is_on_windows else f"-{version}"),
         f"-style={style}",
         "--output-replacements-xml",
     ]
-    if sys.platform.startswith("win32") and os.path.exists(version):
+    if is_on_windows and os.path.exists(version):
         cmds[0] = f"{version}\\clang-format.exe"
+    elif not is_on_windows and not version.isdigit():
+        logger.warning("ignoring invalid version number %s.", version)
+        cmds[0] = "clang-format"
     if lines_changed_only:
         for line_range in file_obj["line_filter"]["lines"]:
             cmds.append(f"--lines={line_range[0]}:{line_range[1]}")

--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -111,6 +111,7 @@ cli_arg_parser.add_argument(
     "with the filename. Prefix a path with '!' to explicitly not ignore it.",
 )
 cli_arg_parser.add_argument(
+    "-l",
     "--lines-changed-only",
     default="false",
     type=lambda input: input.lower() == "true",
@@ -118,6 +119,7 @@ cli_arg_parser.add_argument(
     "Defaults to %(default)s.",
 )
 cli_arg_parser.add_argument(
+    "-f",
     "--files-changed-only",
     default="false",
     type=lambda input: input.lower() == "true",
@@ -125,6 +127,7 @@ cli_arg_parser.add_argument(
     "Defaults to %(default)s.",
 )
 cli_arg_parser.add_argument(
+    "-t",
     "--thread-comments",
     default="false",
     type=lambda input: input.lower() == "true",

--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -84,7 +84,7 @@ cli_arg_parser.add_argument(
     "--version",
     default="10",
     help="The desired version of the clang tools to use. Accepted options are strings "
-    "which can be 6.0, 7, 8, 9, 10, 11, 12. Defaults to %(default)s. On Windows, this "
+    "which can be 8, 9, 10, 11, 12, 13, 14. Defaults to %(default)s. On Windows, this "
     "can also be a path to the install location of LLVM",
 )
 cli_arg_parser.add_argument(

--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -394,6 +394,8 @@ def run_clang_tidy(
     cmds = [f"clang-tidy-{version}"]
     if sys.platform.startswith("win32"):
         cmds = ["clang-tidy"]
+        if os.path.exists(version):
+            cmds = [f"{version}\\clang-tidy.exe"]
     if checks:
         cmds.append(f"-checks={checks}")
     cmds.append("--export-fixes=clang_tidy_output.yml")
@@ -445,6 +447,8 @@ def run_clang_format(
         f"-style={style}",
         "--output-replacements-xml",
     ]
+    if sys.platform.startswith("win32") and os.path.exists(version):
+        cmds[0] = f"{version}\\clang-format.exe"
     if lines_changed_only:
         for line_range in file_obj["line_filter"]["lines"]:
             cmds.append(f"--lines={line_range[0]}:{line_range[1]}")

--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -394,8 +394,8 @@ def run_clang_tidy(
     cmds = [f"clang-tidy-{version}"]
     if sys.platform.startswith("win32"):
         cmds = ["clang-tidy"]
-        if os.path.exists(version):
-            cmds = [f"{version}\\clang-tidy.exe"]
+        if os.path.exists(version + os.sep + "bin"):
+            cmds = [f"{version}\\bin\\clang-tidy.exe"]
     elif not version.isdigit():
         logger.warning("ignoring invalid version number %s.", version)
         cmds = ["clang-tidy"]
@@ -451,8 +451,8 @@ def run_clang_format(
         f"-style={style}",
         "--output-replacements-xml",
     ]
-    if is_on_windows and os.path.exists(version):
-        cmds[0] = f"{version}\\clang-format.exe"
+    if is_on_windows and os.path.exists(version + os.sep + "bin"):
+        cmds[0] = f"{version}\\bin\\clang-format.exe"
     elif not is_on_windows and not version.isdigit():
         logger.warning("ignoring invalid version number %s.", version)
         cmds[0] = "clang-format"


### PR DESCRIPTION
The only way to use this action on a Windows-based CI runner is by using the python src code as an installed python package. In that context, some concessions needed to be made to achieve expected behavior.
- allow a path to clang-tools be passed to `version` option (on windows platform)
   - This isn't needed on Ubuntu since multiple versions can co-exist (and they're appended with the version number), but Windows install locations need to differ when installing multiple versions of clang-tools (version number is not appended).
   - The `windows-latest` (aka `windows-2022`) runner already includes LLVM v13.0.1
   - specifying a path to the clang-tools' executable on Ubuntu **should be ignored** as long as the path isn't just a digit.
   
   Example: When LLVM+Clang is installed to `${{ github.workspace }}/.llvm` you can now specify that path using
   ```
   cpp-linter --version="${{ github.workspace }}/.llvm"
   ```
   Note, `/bin` is appended automatically because this is where the clang-tidy.exe and clang-format.exe exist within the installation's path. Its also worth mentioning that `cpp-linter` is equivalent to `python3 -m cpp_linter.run` (as it has always been since switching to python). Maybe the later is clearer though.
- create annotations with filename using Posix path delimiters when env is a CI runner (not needed for env that aren't github runners like a local machine).
   - This fixes annotation not appearing in the event's diff when `cpp_linter` package is executed on a Windows-based runner.
- add some type hinting to clang_tidy.py
- updated README with a simple example using a Windows-based runner
