### PR TITLE
docs: Update README and bump version to 1.4.2

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -10,7 +10,7 @@ jobs:
   cpp-linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: shenxianpeng/cpp-linter-action@master
         id: linter
         env:

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ jobs:
   cpp-linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: shenxianpeng/cpp-linter-action@v1.4.2
+      - uses: actions/checkout@v3
+      - uses: shenxianpeng/cpp-linter-action@v1
         id: linter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -163,7 +163,7 @@ jobs:
           directory: ${{ runner.temp }}/llvm
 
       - name: Install linter python package
-        run: python3 -m pip install git+https://github.com/shenxianpeng/cpp-linter-action@v1.4.2
+        run: python3 -m pip install git+https://github.com/shenxianpeng/cpp-linter-action@v1
 
       - name: run linter as a python package
         id: linter

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: shenxianpeng/cpp-linter-action@master
+      - uses: shenxianpeng/cpp-linter-action@v1.4.2
         id: linter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -163,7 +163,7 @@ jobs:
           directory: ${{ runner.temp }}/llvm
 
       - name: Install linter python package
-        run: python3 -m pip install git+https://github.com/shenxianpeng/cpp-linter-action
+        run: python3 -m pip install git+https://github.com/shenxianpeng/cpp-linter-action@v1.4.2
 
       - name: run linter as a python package
         id: linter

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,7 @@ from setuptools import setup
 ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
 REPO = "https://github.com/"
 repo = os.getenv("GITHUB_REPOSITORY", None)  # in case this is published from a fork
-REPO += "" if repo is None else repo
-if repo is None:
-    REPO += "2bndy5/cpp-linter-action"
+REPO += "shenxianpeng/cpp-linter-action" if repo is None else repo
 
 
 setup(
@@ -17,14 +15,17 @@ setup(
     # setup_requires=["setuptools_scm"],
     version="1.4.2",
     description=__doc__,
-    long_description=".. warning:: this is not meant for PyPi (yet)",
-    author="Brendan Doherty",
+    long_description=(
+        "A python package that powers the github action named cpp-linter-action. "
+        + f"See `the github repository README <{REPO}#readme>`_ for full details."
+    ),
+    author="Brendan Doherty, Peter Shen",
     author_email="2bndy5@gmail.com",
     install_requires=["requests", "pyyaml"],  # pyyaml is installed with clang-tidy
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
-        "Development Status :: 1 - Production/Alpha",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     name="cpp_linter",
     # use_scm_version=True,
     # setup_requires=["setuptools_scm"],
-    version="1.3.1",
+    version="1.4.2",
     description=__doc__,
     long_description=".. warning:: this is not meant for PyPi (yet)",
     author="Brendan Doherty",


### PR DESCRIPTION
I assume to bump the version to 1.4.2 because

1. The current version in setup.py is incorrect, it is 1.3.1
2. update README based on suggestion in https://github.com/shenxianpeng/cpp-linter-action/issues/55#issuecomment-1106666257